### PR TITLE
Fix attempt for issue with state file names when the state file name is user defined.

### DIFF
--- a/src/beast/coupledMCMC/HeatedChain.java
+++ b/src/beast/coupledMCMC/HeatedChain.java
@@ -1,30 +1,20 @@
 package beast.coupledMCMC;
 
 
+import beast.core.*;
+import beast.core.Citation.Citations;
+import beast.core.util.Evaluator;
+import beast.core.util.Log;
+import beast.util.Randomizer;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.xml.sax.SAXException;
-
-import beast.core.Citation;
-import beast.core.Description;
-import beast.core.Distribution;
-import beast.core.Input;
-import beast.core.Logger;
-import beast.coupledMCMC.CoupledLogger;
-import beast.core.MCMC;
-import beast.core.Operator;
-import beast.core.OperatorSchedule;
-import beast.core.StateNodeInitialiser;
-import beast.core.Citation.Citations;
-import beast.core.util.Evaluator;
-import beast.core.util.Log;
 //import beast.util.Randomizer;
-import beast.util.Randomizer;
 
 @Citations(
 		{
@@ -393,5 +383,19 @@ public class HeatedChain extends MCMC {
         }
     } // log
 
+
+    @Override
+    /**
+     * Set up information related to the file for (re)storing the State.
+     * The Runnable implementation is responsible for making its
+     * State synchronising with the file *
+     * @param fileName
+     * @param isRestoreFromFile
+     */
+    public void setStateFile(final String fileName, final boolean isRestoreFromFile) {
+
+        stateFileName = fileName;
+        restoreFromFile = isRestoreFromFile;
+    }
 	
 }


### PR DESCRIPTION
I noticed a bug when using CoupledMCMC, the state files are mangled, written on top of themselves, preventing the MCMC chain from resuming. 
I think the bug comes from the use of the `setStateFile` method in the `Runnable` class. `setStateFile` only assigns `fileName` to the `stateFileName` variable if the the state file name is not user-defined already, so if the `-state` option is not used when launching beast.
So when using a `-state` option, all the `setStateFile(filename)` calls from `HeatedChain` are void, since the `stateFileName` variable is assigned back to the content of the `-state` option. 
I tried to fix that by overriding the `setStateFile` method in `HeatedChain`. It seems to work, I'm able to use the `-state` option and resume analysis.

PS: I just noticed the changes in imports that my commit has. I'm not sure where they come from, they are not intentional on my part. Feel free to reject the pull request if that causes an issue.