### PR TITLE
ci: clean-deploy on tag and skip redundant verify

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -44,11 +44,12 @@ jobs:
           mvn versions:set -DnewVersion=$VERSION -DgenerateBackupPoms=false
 
       - name: Build and test
+        if: "!startsWith(github.ref, 'refs/tags/v')"
         run: mvn verify
 
       - name: Publish to Maven Central
         if: startsWith(github.ref, 'refs/tags/v')
-        run: mvn deploy -Prelease -DskipTests
+        run: mvn -Prelease clean deploy
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}


### PR DESCRIPTION
## Summary
- Gate `Build and test` to non-tag pushes — the same `mvn verify` runs as part of the deploy lifecycle on tag, so it was running twice on tag pushes.
- Replace two-step `mvn deploy -Prelease -DskipTests` with single `mvn -Prelease clean deploy`. The previous flow could leave unsigned package outputs in `target/` from an earlier run, so the second invocation deployed artifact bytes that did not match the freshly generated `.asc` files. Sonatype rejected such tag releases with `Invalid signature` on `zip/sources/javadoc` while `jar/pom` verified. A single clean deploy from the tag avoids that.

Same fix that landed on `morph-models` (db64781), `BEASTLabs` (a13e75b), and `beast-classic` (8baef54).

## Test plan
- [ ] Push to non-tag branch: `Build and test` runs (mvn verify), publish step skipped.
- [ ] Tag push (`v*`): `Build and test` skipped, `Publish to Maven Central` runs `mvn -Prelease clean deploy`.
