### PR TITLE
Bump beast.version to 2.8.0-beta5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>25</maven.compiler.release>
 
-        <beast.version>2.8.0-beta4</beast.version>
+        <beast.version>2.8.0-beta5</beast.version>
         <javafx.version>25.0.2</javafx.version>
         <junit.version>5.8.2</junit.version>
 


### PR DESCRIPTION
Bumps `beast.version` from 2.8.0-beta4 to 2.8.0-beta5 (latest available on Maven Central). Coordinated with the matching bump in CompEvol/Mascot.