### PR TITLE
Bump project version to 1.3.0-beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.compevol</groupId>
     <artifactId>coupled-mcmc</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.0-beta1</version>
 
     <name>CoupledMCMC</name>
     <description>Coupled MCMC (MC3) for BEAST</description>


### PR DESCRIPTION
Bumps CoupledMCMC project version from 1.3.0-SNAPSHOT to 1.3.0-beta1 in preparation for the beta1 release tag.