### PR TITLE
Update repo URLs and Nicola's name spelling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <name>CoupledMCMC</name>
     <description>Coupled MCMC (MC3) for BEAST</description>
 
-    <url>https://github.com/nicfel/CoupledMCMC</url>
+    <url>https://github.com/CompEvol/CoupledMCMC</url>
 
     <licenses>
         <license>
@@ -32,9 +32,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/nicfel/CoupledMCMC.git</connection>
-        <developerConnection>scm:git:ssh://github.com:nicfel/CoupledMCMC.git</developerConnection>
-        <url>https://github.com/nicfel/CoupledMCMC</url>
+        <connection>scm:git:git://github.com/CompEvol/CoupledMCMC.git</connection>
+        <developerConnection>scm:git:ssh://github.com:CompEvol/CoupledMCMC.git</developerConnection>
+        <url>https://github.com/CompEvol/CoupledMCMC</url>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <developers>
         <developer>
-            <name>Nicola Müller</name>
+            <name>Nicola F. Müller</name>
             <url>https://github.com/nicfel</url>
         </developer>
         <developer>


### PR DESCRIPTION
Updates the project `<url>`, SCM `<connection>`, `<developerConnection>`, and SCM `<url>` to point at CompEvol/CoupledMCMC now that the repo has been transferred. Also corrects the developer name to Nicola's preferred form 'Nicola F. Müller' (per his Google Scholar profile). Other developer entries are left unchanged.