### PR TITLE
Bump README Maven version to 1.3.0-beta1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Parallel tempering (Metropolis-coupled MCMC) for [BEAST 3](https://github.com/Co
 <dependency>
     <groupId>io.github.compevol</groupId>
     <artifactId>coupled-mcmc</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.0-beta1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Updates the Maven coordinates snippet in README to match the project version (1.3.0-beta1).