### PR TITLE
Set beast.pkg.version to 1.3.0 to match version.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <beast.main>beast.base.minimal.BeastMain</beast.main>
         <beast.args/>
         <beast.pkg.name>CoupledMCMC</beast.pkg.name>
-        <beast.pkg.version>1.3.0-SNAPSHOT</beast.pkg.version>
+        <beast.pkg.version>1.3.0</beast.pkg.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary
- PR #27 bumped `<version>` to `1.3.0-beta1` but left `<beast.pkg.version>` at `1.3.0-SNAPSHOT`.
- `finalName` for the assembly is `${beast.pkg.name}.v${beast.pkg.version}`, so the package ZIP was being built as `CoupledMCMC.v1.3.0-SNAPSHOT.zip` instead of `CoupledMCMC.v1.3.0.zip`.
- Per the BEAST3 add-on release convention (version.xml/ZIP keep `.0`, git tag carries `-betaN`), `beast.pkg.version` should track `version.xml` not the pom `<version>`.

## Test plan
- [x] `./release.sh` produces `target/CoupledMCMC.v1.3.0.zip`
- [ ] CI green